### PR TITLE
Add the ability to encrypt and decrypt strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,6 @@ ExceptionInfo Invalid token.  clojure.core/ex-info (core.clj:4327)
 
 ## Todo
 
-* encrypt/decrypt string messages
 * encrypt/decrypt edn terms
 * autodoc?
 

--- a/src/fernet/core.clj
+++ b/src/fernet/core.clj
@@ -85,8 +85,22 @@
     (catch Exception e
       (invalid-token))))
 
-(defn encrypt [key message]
-  (String. (encrypt-message key message)))
-
 (defn decrypt [key token & options]
   (apply decrypt-token key token options))
+
+(defn decrypt-to-string
+  [key token & options]
+  (String. (apply decrypt-token key token options)))
+
+(defn- ->token-string [key message]
+  (String. (encrypt-message key message)))
+
+(defmulti encrypt (fn [_  message-text] (class message-text)))
+
+(defmethod encrypt String [key message]
+  (let [message-bytes (byte-array (map byte message))
+        token (->token-string key message-bytes)]
+    token))
+
+(defmethod encrypt (Class/forName "[B") [key message]
+  (->token-string key message))

--- a/test/fernet/core_test.clj
+++ b/test/fernet/core_test.clj
@@ -86,4 +86,13 @@
   (testing "encrypt/decrypt round trip"
     (is (java.util.Arrays/equals
           (byte-array (map byte "hello world"))
-          (decrypt k (encrypt k (byte-array (map byte "hello world"))))))))
+          (decrypt k (encrypt k (byte-array (map byte "hello world")))))))
+  (testing "encrypt/decrypt-string round trip"
+    (is (= "hello world"
+           (decrypt-to-string k (encrypt k "hello world"))))
+    (is (= "hello world"
+           (decrypt-to-string k (encrypt k "hello world") :ttl 15))
+        "round trip passes with valid ttl")
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (decrypt-to-string k (encrypt k "hello world") :ttl -1))
+        "exceptions bubble up to caller")))


### PR DESCRIPTION
Provide a multimethod for encryption that accepts either strings
or byte-arrays.

Decryption is somewhat different in that a user might actually want
the byte-array versus the string. As such, this provides a new function
`decrypt-string` that will decrypt a token and convert it directly to
a string. The arguments to decrypt and decrypt-string are the same.

The private function `->token-string` is meant to dry up the code; but I could
see an argument for inlining it into the multimethod as well.

I've also added tests for the new behaviour.

Thanks for fernet-clj!