### PR TITLE
Update old deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: clojure
 jdk:
 - oraclejdk8
@@ -7,5 +8,6 @@ cache:
   - "$HOME/.m2"
 script:
   - lein test
+  - lein ancient
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -3,16 +3,17 @@
   :url "https://github.com/derwolfe/fernet-clj"
   :license {:name "MIT"
             :url "https://raw.github.com/derwolfe/fernet-clj/master/LICENSE"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.bouncycastle/bcprov-jdk15on "1.49"]
-                 [commons-codec/commons-codec "1.8"]
-                 [clojurewerkz/buffy "0.3.0"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.bouncycastle/bcprov-jdk15on "1.54"]
+                 [commons-codec/commons-codec "1.10"]
+                 [clojurewerkz/buffy "1.0.2"]]
   :profiles {:dev {:resource-paths ["test/resources"]
-                   :dependencies [[org.clojure/data.json "0.2.3"]
-                                  [clj-time "0.6.0"]
-                                  [perforate "0.3.3"]]
+                   :dependencies [[org.clojure/data.json "0.2.6"]
+                                  [clj-time "0.11.0"]
+                                  [perforate "0.3.4"]]
                    :plugins [[perforate "0.3.3"]
-                             [lein-autodoc "0.9.0"]]}}
+                             [lein-autodoc "0.9.0"]
+                             [lein-ancient "0.6.8"]]}}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :global-vars {*warn-on-reflection* true})

--- a/src/fernet/frame.clj
+++ b/src/fernet/frame.clj
@@ -1,10 +1,10 @@
 (ns fernet.frame
-  (:require [clojurewerkz.buffy.core :refer :all]
-            [clojurewerkz.buffy.types.protocols :refer :all]))
+  (:require [clojurewerkz.buffy.core :as bc]
+            [clojurewerkz.buffy.types.protocols :as bp]))
 
 ;; extend buffy
 (deftype UByteType []
-  BuffyType
+  bp/BuffyType
   (size [_] 1)
   (write [bt buffer idx value]
     (.setByte buffer idx value))
@@ -14,20 +14,20 @@
 (def ubyte-type (memoize #(UByteType.)))
 
 (def token-spec {:version (ubyte-type)
-                 :timestamp (long-type)
-                 :iv (bytes-type 16)
+                 :timestamp (bc/long-type)
+                 :iv (bc/bytes-type 16)
                  :ciphertext nil
-                 :hmac (bytes-type 32)})
+                 :hmac (bc/bytes-type 32)})
 
 (def overhead
-  (apply + (map #(size (second %)) (dissoc token-spec :ciphertext))))
+  (apply + (map #(bp/size (second %)) (dissoc token-spec :ciphertext))))
 
 (defn token-buf [ciphertext-length]
-  (let [spec (assoc token-spec :ciphertext (bytes-type ciphertext-length))]
-    (compose-buffer spec :buffer-type :heap)))
+  (let [spec (assoc token-spec :ciphertext (bc/bytes-type ciphertext-length))]
+    (bc/compose-buffer spec :buffer-type :heap)))
 
 (defn fill-buffer [buf b]
-  (.setBytes (buffer buf) 0 b)
+  (.setBytes (bc/buffer buf) 0 b)
   buf)
 
 (defn get-bytes
@@ -43,16 +43,16 @@
   (let [ciphertext-length (alength ciphertext)
         signed-length (- (+ overhead ciphertext-length) 32)
         buf (token-buf ciphertext-length)]
-    (set-fields buf {:version version
-                     :timestamp timestamp
-                     :iv iv
-                     :ciphertext ciphertext})
-    (set-field buf :hmac (hmac-fn (get-bytes (buffer buf) signed-length)))
-    (.array (buffer buf))))
+    (bc/set-fields buf {:version version
+                        :timestamp timestamp
+                        :iv iv
+                        :ciphertext ciphertext})
+    (bc/set-field buf :hmac (hmac-fn (get-bytes (bc/buffer buf) signed-length)))
+    (.array (bc/buffer buf))))
 
 (defn decode-token
   [b]
   (let [signed-length (- (alength b) 32)
         buf (token-buf (- (alength b) overhead))]
     (fill-buffer buf b)
-    (assoc (decompose buf) :signed (get-bytes (buffer buf) signed-length))))
+    (assoc (bc/decompose buf) :signed (get-bytes (bc/buffer buf) signed-length))))

--- a/src/fernet/frame.clj
+++ b/src/fernet/frame.clj
@@ -43,10 +43,10 @@
   (let [ciphertext-length (alength ciphertext)
         signed-length (- (+ overhead ciphertext-length) 32)
         buf (token-buf ciphertext-length)]
-    (bc/set-fields buf {:version version
-                        :timestamp timestamp
-                        :iv iv
-                        :ciphertext ciphertext})
+    (bc/compose buf {:version version
+                     :timestamp timestamp
+                     :iv iv
+                     :ciphertext ciphertext})
     (bc/set-field buf :hmac (hmac-fn (get-bytes (bc/buffer buf) signed-length)))
     (.array (bc/buffer buf))))
 


### PR DESCRIPTION
1. Use lein ancient to find old dependencies.
2. Refactor `fernet.frame` to use namspaces instead of `:refer :all` from buffy to eliminate a few function and protocol overrides.